### PR TITLE
feat(backend): integrate CV service via WebClient for document classi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,10 @@
             <artifactId>postgres-socket-factory</artifactId>
             <version>1.19.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/verikyc/repoverikycbackend/client/CvServiceClient.java
+++ b/src/main/java/com/verikyc/repoverikycbackend/client/CvServiceClient.java
@@ -1,0 +1,46 @@
+package com.verikyc.repoverikycbackend.client;
+
+import com.verikyc.repoverikycbackend.dto.CvPredictResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CvServiceClient {
+
+    private final WebClient webClient;
+
+    public CvServiceClient(@Value("${cv.service.url}") String cvServiceUrl) {
+        this.webClient = WebClient.builder()
+                .baseUrl(cvServiceUrl)
+                .build();
+    }
+
+    public CvPredictResponse predict(MultipartFile file) throws IOException {
+        MultipartBodyBuilder builder = new MultipartBodyBuilder();
+        builder.part("file", new ByteArrayResource(file.getBytes()) {
+            @Override
+            public String getFilename() {
+                return file.getOriginalFilename();
+            }
+        }).contentType(MediaType.valueOf(file.getContentType()));
+
+        return webClient.post()
+                .uri("/api/v1/predict")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(builder.build()))
+                .retrieve()
+                .bodyToMono(CvPredictResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/com/verikyc/repoverikycbackend/dto/CvPredictResponse.java
+++ b/src/main/java/com/verikyc/repoverikycbackend/dto/CvPredictResponse.java
@@ -1,0 +1,9 @@
+package com.verikyc.repoverikycbackend.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CvPredictResponse(
+        @JsonProperty("document_type") String documentType,
+        float confidence
+) {
+}

--- a/src/main/java/com/verikyc/repoverikycbackend/service/DocumentService.java
+++ b/src/main/java/com/verikyc/repoverikycbackend/service/DocumentService.java
@@ -1,9 +1,12 @@
 package com.verikyc.repoverikycbackend.service;
 
+import com.verikyc.repoverikycbackend.client.CvServiceClient;
+import com.verikyc.repoverikycbackend.dto.CvPredictResponse;
 import com.verikyc.repoverikycbackend.dto.DocumentDetailResponse;
 import com.verikyc.repoverikycbackend.dto.DocumentResponse;
 import com.verikyc.repoverikycbackend.dto.PageDocumentResponse;
 import com.verikyc.repoverikycbackend.enums.DocumentStatus;
+import com.verikyc.repoverikycbackend.enums.DocumentType;
 import com.verikyc.repoverikycbackend.enums.Role;
 import com.verikyc.repoverikycbackend.exception.DocumentNotFoundException;
 import com.verikyc.repoverikycbackend.exception.FileSizeLimitExceededException;
@@ -37,6 +40,7 @@ import java.util.UUID;
 public class DocumentService {
 
     private final DocumentRepository documentRepository;
+    private final CvServiceClient cvServiceClient;
 
     @Value("${storage.upload.path}")
     private String uploadPath;
@@ -74,6 +78,21 @@ public class DocumentService {
         DocumentEntity savedDocument = documentRepository.save(document);
 
         log.info("Document uploaded: id={}, user={}", savedDocument.getId(), userEntity.getId());
+
+        try{
+            CvPredictResponse cvResponse = cvServiceClient.predict(documentImage);
+            log.info("CV classification: id={}, type={}, confidence={}",
+                    savedDocument.getId(), cvResponse.documentType(), cvResponse.confidence());
+            savedDocument.setDocumentType(DocumentType.valueOf(cvResponse.documentType()));
+            savedDocument.setStatus(DocumentStatus.PROCESSING);
+        }
+        catch (Exception e) {
+            log.error("CV service failed: id={}, cause={}", savedDocument.getId(), e.getMessage());
+            savedDocument.setStatus(DocumentStatus.FAILED);
+        }
+
+        documentRepository.save(savedDocument);
+
         return new DocumentResponse(savedDocument.getId(),
                 savedDocument.getStatus(),
                 savedDocument.getCreatedAt());

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -5,3 +5,5 @@ spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
 spring.jpa.show-sql=false
 spring.jpa.hibernate.ddl-auto=update
+
+cv.service.url=https://verikyc-cv-<your-hash>.us-central1.run.app

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -5,3 +5,5 @@ spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
+
+cv.service.url=http://localhost:8000


### PR DESCRIPTION
…fication (Issue #19)

  - Add CvServiceClient: multipart POST to CV /predict endpoint
  - Add CvPredictResponse DTO with snake_case JsonProperty mapping
  - Update DocumentService: call CV after upload, update document_type and status
  - Add cv.service.url to local and dev properties
  - On CV failure: status set to FAILED with error logging